### PR TITLE
Portability changes

### DIFF
--- a/CCx.cpp
+++ b/CCx.cpp
@@ -34,7 +34,7 @@ CCX::CCX(){}
 // Power On Reset as described in  19.1.2 of cc1100 datasheet, tried APOR as described in 19.1.1 but that did not work :-(
 void CCX::PowerOnStartUp()
 {
-   Spi.mode((0 << SPR1) | (0 << SPR0));//SPICLK=CPU/4
+   Spi.mode( ( 1<<SPR1 ) | ( 1<<SPR0 ) );//SPICLK=CPU/128
 
    // start manual Power On Reset
    Spi.slaveSelect(HIGH);

--- a/EvohomeWirelessFW.ino
+++ b/EvohomeWirelessFW.ino
@@ -546,6 +546,7 @@ void loop() {
        detachInterrupt(GDO2_INT);
        while(((CCx.Write(CCx_SIDLE,0)>>4)&7)!=0);
        while(((CCx.Write(CCx_STX,0)>>4)&7)!=2);//will calibrate when going to tx
+       PORTD |= GDO0_PD;  // Force start in mark when we switch to TX
        pinMode(GDO0_PIN,OUTPUT);
        sm=pmSendActive;
        highnib=true;

--- a/EvohomeWirelessFW.ino
+++ b/EvohomeWirelessFW.ino
@@ -34,11 +34,10 @@
 
 #define VERSION_NO "0.8"
 
-#define GDO0_INT 0 // INT0(PD2) wired to GDO0 on CC1101
-#define GDO2_INT 1 // INT1(PD3) wired to GDO2 on CC1101 (CCx_IOCFG2==0x0B Serial Clock. Synchronous to the data in synchronous serial mode. In RX mode, data is set up on the falling edge by CC1101 when GDOx_INV=0. In TX mode, data is sampled by CC1101 on the rising edge of the serial clock when GDOx_INV=0.)
+#define GDO2_INT INT1    // INT1(PD3) wired to GDO2 on CC1101 (CCx_IOCFG2==0x0B Serial Clock. Synchronous to the data in synchronous serial mode. In RX mode, data is set up on the falling edge by CC1101 when GDOx_INV=0. In TX mode, data is sampled by CC1101 on the rising edge of the serial clock when GDOx_INV=0.)
 
-#define GDO0_PD 4 // PD2(INT0) wired to GDO0 on CC1101 (CCx_IOCFG0==0x0C Serial Synchronous Data Output. Used for synchronous serial mode.)
-#define GDO2_PD 8 // PD3(INT1) wired to GDO2 on CC1101
+#define GDO0_PD (1<<PD2) // PD2(INT0) wired to GDO0 on CC1101 (CCx_IOCFG0==0x0C Serial Synchronous Data Output. Used for synchronous serial mode.)
+#define GDO0_PIN 2       // PD2(INT0) 
 
 #define SYNC_ON_32BITS
 
@@ -547,7 +546,7 @@ void loop() {
        detachInterrupt(GDO2_INT);
        while(((CCx.Write(CCx_SIDLE,0)>>4)&7)!=0);
        while(((CCx.Write(CCx_STX,0)>>4)&7)!=2);//will calibrate when going to tx
-       pinMode(2,OUTPUT);
+       pinMode(GDO0_PIN,OUTPUT);
        sm=pmSendActive;
        highnib=true;
        bit_counter=0;

--- a/EvohomeWirelessFW.ino
+++ b/EvohomeWirelessFW.ino
@@ -311,7 +311,7 @@ void loop() {
     circ_buffer.push(0x35,true);
     pinMode(2,INPUT);
     while(((CCx.Write(CCx_SRX,0)>>4)&7)!=1); 
-    attachInterrupt(GDO2_INT, sync_clk_in, FALLING);
+    attachInterrupt(GDO2_INT, sync_clk_in, RISING);
     pp=0;
     op=0;
     sp=0;
@@ -557,6 +557,6 @@ void loop() {
        pp=0;
        out_flags=0;//reuse for preamble counter
        circ_buffer.push(0x53,true); //don't push anything while interrupt is running
-       attachInterrupt(GDO2_INT, sync_clk_out, RISING);
+       attachInterrupt(GDO2_INT, sync_clk_out, FALLING);
   }
 }

--- a/EvohomeWirelessFW.ino
+++ b/EvohomeWirelessFW.ino
@@ -38,6 +38,8 @@
 
 #define GDO0_PD (1<<PD2) // PD2(INT0) wired to GDO0 on CC1101 (CCx_IOCFG0==0x0C Serial Synchronous Data Output. Used for synchronous serial mode.)
 #define GDO0_PIN 2       // PD2(INT0) 
+#define GDO_PORT PORTD
+#define GDO_PIN  PIND
 
 #define SYNC_ON_32BITS
 
@@ -130,7 +132,7 @@ char param[10];
 
 // Interrupt to receive data and find_sync_word
 void sync_clk_in() {
-    byte new_bit=(PIND & GDO0_PD); //sync data
+    byte new_bit=(GDO_PIN & GDO0_PD); //sync data
           
     //keep our buffer rolling even when we're in sync
     sync_buffer<<=1;
@@ -214,7 +216,7 @@ void sync_clk_out() {
     {
       if(!bit_counter)
       {
-        PORTD&=~GDO0_PD;
+        GDO_PORT &= ~GDO0_PD;
         if(out_flags<5)
         {
           byte_buffer=0x55;
@@ -255,16 +257,16 @@ void sync_clk_out() {
       else
       {
         if(byte_buffer&0x01)
-          PORTD|=GDO0_PD;
+          GDO_PORT |=  GDO0_PD;
         else
-          PORTD&=~GDO0_PD;
+          GDO_PORT &= ~GDO0_PD;
         byte_buffer>>=1;
       }
       bit_counter++;
     }
     else
     {
-      PORTD|=GDO0_PD;
+      GDO_PORT |= GDO0_PD;
       bit_counter=0;
     }
 }
@@ -546,7 +548,7 @@ void loop() {
        detachInterrupt(GDO2_INT);
        while(((CCx.Write(CCx_SIDLE,0)>>4)&7)!=0);
        while(((CCx.Write(CCx_STX,0)>>4)&7)!=2);//will calibrate when going to tx
-       PORTD |= GDO0_PD;  // Force start in mark when we switch to TX
+       GDO_PORT |= GDO0_PD;  // Force start in mark when we switch to TX
        pinMode(GDO0_PIN,OUTPUT);
        sm=pmSendActive;
        highnib=true;

--- a/EvohomeWirelessFW.ino
+++ b/EvohomeWirelessFW.ino
@@ -311,7 +311,7 @@ void loop() {
     circ_buffer.push(0x35,true);
     pinMode(2,INPUT);
     while(((CCx.Write(CCx_SRX,0)>>4)&7)!=1); 
-    attachInterrupt(GDO2_INT, sync_clk_in, RISING);
+    attachInterrupt(GDO2_INT, sync_clk_in, FALLING);
     pp=0;
     op=0;
     sp=0;
@@ -557,6 +557,6 @@ void loop() {
        pp=0;
        out_flags=0;//reuse for preamble counter
        circ_buffer.push(0x53,true); //don't push anything while interrupt is running
-       attachInterrupt(GDO2_INT, sync_clk_out, FALLING);
+       attachInterrupt(GDO2_INT, sync_clk_out, RISING);
   }
 }


### PR DESCRIPTION
Dan,

I'm porting EvohomeWirelessFw to my ATMega32U4 as a precursor to using it for testing the hardware UART.  I suspect this firmware is going to be a simpler place to start

These changes simplify the processing of porting from one board to another (similar to hw directory in evofw2)

Also, the last commit is a bugfix.  The data is being set/sampled on the wrong edge of the GDO2 clock. It must be set/sampled on the **opposite** edge to where the CC1101 samples/sets it

